### PR TITLE
Add flux@0.41 formula

### DIFF
--- a/Formula/flux@0.41.rb
+++ b/Formula/flux@0.41.rb
@@ -1,0 +1,86 @@
+# typed: false
+# frozen_string_literal: true
+
+class FluxAT041 < Formula
+  desc "Flux CLI"
+  homepage "https://fluxcd.io/"
+  version "0.41.2"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_darwin_amd64.tar.gz"
+      sha256 "bba5d3e98c5e92ace0189493fb40491180b998d7a03093c91022b73a0e0c3883"
+
+      def install
+        bin.install "flux"
+
+        bash_output = Utils.safe_popen_read(bin/"flux", "completion", "bash")
+        (bash_completion/"flux").write bash_output
+
+        zsh_output = Utils.safe_popen_read(bin/"flux", "completion", "zsh")
+        (zsh_completion/"_flux").write zsh_output
+
+        fish_output = Utils.safe_popen_read(bin/"flux", "completion", "fish")
+        (fish_completion/"flux.fish").write fish_output
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_darwin_arm64.tar.gz"
+      sha256 "ea5a97c7eca727b7f3b63f3e05589f1b244fd38f1095644e9cde7378f78c0bbe"
+
+      def install
+        bin.install "flux"
+
+        bash_output = Utils.safe_popen_read(bin/"flux", "completion", "bash")
+        (bash_completion/"flux").write bash_output
+
+        zsh_output = Utils.safe_popen_read(bin/"flux", "completion", "zsh")
+        (zsh_completion/"_flux").write zsh_output
+
+        fish_output = Utils.safe_popen_read(bin/"flux", "completion", "fish")
+        (fish_completion/"flux.fish").write fish_output
+      end
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_linux_arm64.tar.gz"
+      sha256 "44ddca2cd9177b0529e10e6e1d978318bf61d9824def2318e9411dc3da9b89e1"
+
+      def install
+        bin.install "flux"
+
+        bash_output = Utils.safe_popen_read(bin/"flux", "completion", "bash")
+        (bash_completion/"flux").write bash_output
+
+        zsh_output = Utils.safe_popen_read(bin/"flux", "completion", "zsh")
+        (zsh_completion/"_flux").write zsh_output
+
+        fish_output = Utils.safe_popen_read(bin/"flux", "completion", "fish")
+        (fish_completion/"flux.fish").write fish_output
+      end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_linux_amd64.tar.gz"
+      sha256 "13f5ab2a93812c26c6b921274c40451d1b29a259da4e9c4d38b112cc4dad562a"
+
+      def install
+        bin.install "flux"
+
+        bash_output = Utils.safe_popen_read(bin/"flux", "completion", "bash")
+        (bash_completion/"flux").write bash_output
+
+        zsh_output = Utils.safe_popen_read(bin/"flux", "completion", "zsh")
+        (zsh_completion/"_flux").write zsh_output
+
+        fish_output = Utils.safe_popen_read(bin/"flux", "completion", "fish")
+        (fish_completion/"flux.fish").write fish_output
+      end
+    end
+  end
+
+  test do
+    system "#{bin}/flux --version"
+  end
+end


### PR DESCRIPTION
Flux2 0.42.1 and Flux2 2.0.0-rc1 are incompatible because of the difference of apiversion.
https://github.com/fluxcd/flux2/releases/tag/v2.0.0-rc.1

When `brew upgrade fluxcd/tap/flux`, flux cli is updated to 2.0.0.-rc1, so this cannot handle resources in controller 0.42.1:

```
$ flux --version
flux version 2.0.0-rc.1
$ flux get ks -A
✗ no matches for kind "Kustomization" in version "kustomize.toolkit.fluxcd.io/v1"
```

cli 0.42.1 should still be distrbuted.
For preserving 0.42 version of cli, and flux formula looks be updated automatically,
I created separate formula flux@0.41 from this commit: https://github.com/fluxcd/homebrew-tap/commit/a8ff766707b712baf4c7b35ff1107c343e96b55a.



## Test

Brought same commit in [master](https://github.com/ikuwow/homebrew-tap/commit/a6e6721207321e6600c3ce6b9da59df203512b22):

```
$ brew install ikuwow/tap/flux@0.41
==> Tapping ikuwow/tap
Cloning into '/opt/homebrew/Library/Taps/ikuwow/homebrew-tap'...
remote: Enumerating objects: 595, done.
remote: Counting objects: 100% (591/591), done.
remote: Compressing objects: 100% (352/352), done.
remote: Total 595 (delta 289), reused 462 (delta 224), pack-reused 4
Receiving objects: 100% (595/595), 87.23 KiB | 950.00 KiB/s, done.
Resolving deltas: 100% (289/289), done.
Tapped 3 formulae (17 files, 127.3KB).
==> Fetching ikuwow/tap/flux@0.41
==> Downloading https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_darwin_arm64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/258469100/f82aaa45-4b69-495d-af90-2d11de2557e1?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20
######################################################################## 100.0%
==> Installing flux@0.41 from ikuwow/tap
==> Caveats
Bash completion has been installed to:
  /opt/homebrew/etc/bash_completion.d
==> Summary
🍺  /opt/homebrew/Cellar/flux@0.41/0.41.2: 6 files, 61.2MB, built in 4 seconds
==> Running `brew cleanup flux@0.41`...
$ flux --version
flux version 0.41.2
```
