### PR TITLE
fix: keg only versioned formulas

### DIFF
--- a/Formula/flux@0.41.rb
+++ b/Formula/flux@0.41.rb
@@ -6,6 +6,8 @@ class FluxAT041 < Formula
   homepage "https://fluxcd.io/"
   version "0.41.2"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v0.41.2/flux_0.41.2_darwin_amd64.tar.gz"

--- a/Formula/flux@2.0.rb
+++ b/Formula/flux@2.0.rb
@@ -6,6 +6,8 @@ class FluxAT20 < Formula
   homepage "https://fluxcd.io/"
   version "2.0.1"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v2.0.1/flux_2.0.1_darwin_amd64.tar.gz"

--- a/Formula/flux@2.1.rb
+++ b/Formula/flux@2.1.rb
@@ -6,6 +6,8 @@ class FluxAT21 < Formula
   homepage "https://fluxcd.io/"
   version "2.1.2"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v2.1.2/flux_2.1.2_darwin_amd64.tar.gz"

--- a/Formula/flux@2.2.rb
+++ b/Formula/flux@2.2.rb
@@ -6,6 +6,8 @@ class FluxAT22 < Formula
   homepage "https://fluxcd.io/"
   version "2.2.3"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v2.2.3/flux_2.2.3_darwin_amd64.tar.gz"

--- a/Formula/flux@2.3.rb
+++ b/Formula/flux@2.3.rb
@@ -6,6 +6,8 @@ class FluxAT23 < Formula
   homepage "https://fluxcd.io/"
   version "2.3.0"
 
+  keg_only :versioned_formula
+
   on_macos do
     on_intel do
       url "https://github.com/fluxcd/flux2/releases/download/v2.3.0/flux_2.3.0_darwin_amd64.tar.gz"

--- a/Formula/flux@2.4.rb
+++ b/Formula/flux@2.4.rb
@@ -6,6 +6,8 @@ class FluxAT24 < Formula
   homepage "https://fluxcd.io/"
   version "2.4.0"
 
+  keg_only :versioned_formula
+
   on_macos do
     on_intel do
       url "https://github.com/fluxcd/flux2/releases/download/v2.4.0/flux_2.4.0_darwin_amd64.tar.gz"

--- a/Formula/flux@2.5.rb
+++ b/Formula/flux@2.5.rb
@@ -7,6 +7,8 @@ class FluxAT25 < Formula
   homepage "https://fluxcd.io/"
   version "2.5.1"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v2.5.1/flux_2.5.1_darwin_amd64.tar.gz"

--- a/Formula/flux@2.6.rb
+++ b/Formula/flux@2.6.rb
@@ -7,6 +7,8 @@ class FluxAT26 < Formula
   homepage "https://fluxcd.io/"
   version "2.6.4"
 
+  keg_only :versioned_formula
+
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/fluxcd/flux2/releases/download/v2.6.4/flux_2.6.4_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fixes https://github.com/fluxcd/homebrew-tap/issues/15